### PR TITLE
[Feature] 테스트용 ClickHouse GKE 내부 배포

### DIFF
--- a/deploy/clickhouse/clickhouse-values.yaml
+++ b/deploy/clickhouse/clickhouse-values.yaml
@@ -1,0 +1,50 @@
+# Altinity Helm Chart 기반 ClickHouse 단일 노드 배포 설정
+# 목적: GKE 테스트용, 코인 실시간 데이터 저장/압축률 실험
+
+clickhouse:
+  configurationFiles:
+    config.d:
+      # Zookeeper 설정 제거 (단일 노드 운영 시 필요 x)
+      zookeeper.xml: ""
+
+  # 사용자 인증 정보
+  users:
+    default:
+      password_secret: test-clickhouse-password  # pragma: allowlist secret
+      networks:
+        - "::/0"         # IPv6 전체 허용 (내부 테스트용)
+        - "0.0.0.0/0"    # IPv4 전체 허용 (운영 환경에서는 제한 예정)
+
+  # 리소스 제한 및 요청 (테스트용)
+  resources:
+    requests:
+      cpu: "500m"
+      memory: "1Gi"
+    limits:
+      cpu: "1"
+      memory: "2Gi"
+
+  # 단일 노드 (테스트용)
+  replicas: 1
+
+  # Docker 이미지
+  image:
+    repository: altinity/clickhouse-server
+    tag: "24.8.14.10459.altinitystable"
+
+# Zookeeper 역할 (비활성화)
+keeper:
+  enabled: false
+  tolerations: []
+
+# 스토리지 설정
+storage:
+  volumeClaimTemplates:
+    - name: data
+      accessMode: ReadWriteOnce
+      storageClassName: standard
+      size: 50Gi
+
+# 서비스 설정
+service:
+  type: ClusterIP  # 외부 노출 없음. 내부 GKE 통신용

--- a/deploy/clickhouse/clickhouse-values.yaml
+++ b/deploy/clickhouse/clickhouse-values.yaml
@@ -15,16 +15,16 @@ clickhouse:
         - "::/0"         # IPv6 전체 허용 (내부 테스트용)
         - "0.0.0.0/0"    # IPv4 전체 허용 (운영 환경에서는 제한 예정)
 
-  # 리소스 제한 및 요청 (테스트용)
+  # 리소스 제한 및 요청
   resources:
     requests:
-      cpu: "500m"
-      memory: "1Gi"
+      cpu: "2"
+      memory: "4Gi"
     limits:
-      cpu: "1"
-      memory: "2Gi"
+      cpu: "4"
+      memory: "8Gi"
 
-  # 단일 노드 (테스트용)
+  # 단일 노드 사용 (GCP Free Tier 할당 고려)
   replicas: 1
 
   # Docker 이미지
@@ -42,8 +42,8 @@ storage:
   volumeClaimTemplates:
     - name: data
       accessMode: ReadWriteOnce
-      storageClassName: standard
-      size: 50Gi
+      storageClassName: balanced
+      size: 100Gi
 
 # 서비스 설정
 service:

--- a/deploy/clickhouse/deploy_clickhouse.sh
+++ b/deploy/clickhouse/deploy_clickhouse.sh
@@ -1,0 +1,22 @@
+echo -e "\n Starting ClickHouse deployment..."
+
+CLICKHOUSE_NAMESPACE="test-clickhouse"
+CLICKHOUSE_RELEASE_NAME="ch-test"
+CLICKHOUSE_SECRET_NAME="test-clickhouse-password"  # pragma: allowlist secret
+
+kubectl create ns "$CLICKHOUSE_NAMESPACE" --dry-run=client -o yaml | kubectl apply -f -
+
+if ! kubectl get secret "$CLICKHOUSE_SECRET_NAME" -n "$CLICKHOUSE_NAMESPACE" >/dev/null 2>&1; then
+  echo "[$CLICKHOUSE_SECRET_NAME] secret does not exist. Aborting deployment."
+  exit 1
+fi
+
+helm repo add altinity https://altinity.github.io/helm-charts || true
+helm repo update
+
+helm upgrade --install "$CLICKHOUSE_RELEASE_NAME" altinity/clickhouse \
+  -f "./clickhouse/clickhouse-values.yaml" \
+  -n "$CLICKHOUSE_NAMESPACE" \
+  --wait
+
+wait_for_pods "$CLICKHOUSE_NAMESPACE"

--- a/deploy/deploy_stacks.sh
+++ b/deploy/deploy_stacks.sh
@@ -31,7 +31,7 @@ create_namespace_and_secret() {
 # =========================
 # 1. Airflow
 # =========================
-echo -e "\n🚀 [1/3] Airflow 배포 시작..."
+echo -e "\n🚀 [1/4] Airflow 배포 시작..."
 create_namespace_and_secret "airflow"
 
 # Cloud SQL Proxy 배포
@@ -48,7 +48,7 @@ helm upgrade --install airflow apache-airflow/airflow \
 # =========================
 # 2. Spark Connect
 # =========================
-echo -e "\n🚀 [2/3] Spark Connect 배포 시작..."
+echo -e "\n🚀 [2/4] Spark Connect 배포 시작..."
 create_namespace_and_secret "spark"
 
 helm repo add sdaberdaku https://sdaberdaku.github.io/charts || true
@@ -64,7 +64,7 @@ wait_for_pods "spark"
 # =========================
 # 3. ELK Stack
 # =========================
-echo -e "\n🚀 [3/3] ELK Stack 배포 시작..."
+echo -e "\n🚀 [3/4] ELK Stack 배포 시작..."
 kubectl create ns elk --dry-run=client -o yaml | kubectl apply -f -
 
 helm repo add elastic https://helm.elastic.co || true
@@ -81,6 +81,32 @@ helm upgrade --install kibana elastic/kibana \
   -n elk
 
 wait_for_pods "elk"
+
+# =========================
+# 4. ClickHouse
+# =========================
+echo -e "\n🚀 [4/4] ClickHouse 배포 시작..."
+
+CLICKHOUSE_NAMESPACE="test-clickhouse"
+CLICKHOUSE_RELEASE_NAME="ch-test"
+CLICKHOUSE_SECRET_NAME="test-clickhouse-password"  # pragma: allowlist secret
+
+kubectl create ns "$CLICKHOUSE_NAMESPACE" --dry-run=client -o yaml | kubectl apply -f -
+
+if ! kubectl get secret "$CLICKHOUSE_SECRET_NAME" -n "$CLICKHOUSE_NAMESPACE" >/dev/null 2>&1; then
+  echo "[$CLICKHOUSE_SECRET_NAME] 시크릿이 존재하지 않습니다. 배포를 중단합니다."
+  exit 1
+fi
+
+helm repo add altinity https://altinity.github.io/helm-charts || true
+helm repo update
+
+helm upgrade --install "$CLICKHOUSE_RELEASE_NAME" altinity/clickhouse \
+  -f "./clickhouse/clickhouse-values.yaml" \
+  -n "$CLICKHOUSE_NAMESPACE" \
+  --wait
+
+wait_for_pods "$CLICKHOUSE_NAMESPACE"
 
 # =========================
 echo -e "\n🎉 모든 서비스 배포 완료!"


### PR DESCRIPTION
## 📌 테스트용 ClickHouse GKE 내부 배포

## ✨ 변경 사항  
- GKE 테스트 환경에서 실시간 데이터 저장 및 압축률 실험을 위한 ClickHouse 단일 노드 배포 설정 추가
- Altinity Helm Chart를 사용하며, Helm 배포 로직을 `deploy_stacks.sh`에 통합

## 📂 변경된 파일  
- `deploy/clickhouse/clickhouse-values.yaml`: ClickHouse Helm 배포 설정 파일
- `deploy/clickhouse/clickhouse_deploy.sh`: ClickHouse Helm 배포 스크립트 추가

## 🚀 변경 유형  
- [x] ✨ 기능 추가 (새로운 기능)  
- [ ] 🐛 버그 수정 (기존 기능 수정)  
- [ ] ♻️ 리팩토링 (코드 구조 개선)  
- [ ] 📝 문서 수정 (README 등 문서 변경)  
- [ ] 🚨 테스트 추가/수정  

## ✅ 체크리스트  
PR을 올리기 전에 아래 사항을 확인해주세요.  
- [x] 코드가 정상적으로 실행됨  
- [ ] 관련 테스트 코드를 추가함  
- [x] 기존 기능에 영향을 주지 않음  
- [ ] 문서를 업데이트했음 (필요한 경우)  

## 💬 기타 참고 사항  
- ClickHouse 비밀번호는 보안을 고려해 Git에 포함하지 않아, 수동 생성 필요 (비밀 채널에 공유)
- 해당 시크릿이 존재하지 않으면 `deploy_stacks.sh` 실행이 중단되도록 안전장치 포함
- lickHouse는 내부 GKE 통신을 위한 ClusterIP 방식으로 배포됨